### PR TITLE
access user_id for triggerd events from kwargs

### DIFF
--- a/appdaemon/events.py
+++ b/appdaemon/events.py
@@ -286,6 +286,7 @@ class Events:
                                 _run = False
 
                         if _run:
+                            callback["kwargs"]["user_id"] = data["context"].get("user_id")
                             if name in self.AD.app_management.objects:
                                 await self.AD.threading.dispatch_worker(name,
                                                                         {


### PR DESCRIPTION
This PR adds the user_id from the context of the fired event to the kwargs returned with the callback.
An app can identify which user triggered the event.